### PR TITLE
Add missing usb_modeswitch.conf file

### DIFF
--- a/Android.mk
+++ b/Android.mk
@@ -23,7 +23,6 @@ LOCAL_SRC_FILES := usb_modeswitch.conf
 LOCAL_MODULE_CLASS := ETC
 LOCAL_MODULE_PATH := $(TARGET_OUT)/etc/
 LOCAL_MODULE_TAGS := optional
-
 include $(BUILD_PREBUILT)
 
 ######################################

--- a/Android.mk
+++ b/Android.mk
@@ -17,5 +17,14 @@ LOCAL_MODULE_PATH := $(TARGET_OUT)/bin/
 LOCAL_MODULE_TAGS := optional
 include $(BUILD_PREBUILT)
 
+include $(CLEAR_VARS)
+LOCAL_MODULE := usb_modeswitch.conf
+LOCAL_SRC_FILES := usb_modeswitch.conf
+LOCAL_MODULE_CLASS := ETC
+LOCAL_MODULE_PATH := $(TARGET_OUT)/etc/
+LOCAL_MODULE_TAGS := optional
+
+include $(BUILD_PREBUILT)
+
 ######################################
 include $(call all-makefiles-under,$(LOCAL_PATH))

--- a/usb_modeswitch.conf
+++ b/usb_modeswitch.conf
@@ -29,4 +29,4 @@ EnableLogging=0
 # Does nothing if the current system value is same or higher
 
 #SetStorageDelay=4
-Enter file contents here
+

--- a/usb_modeswitch.conf
+++ b/usb_modeswitch.conf
@@ -1,0 +1,32 @@
+# Configuration for the usb_modeswitch package, a mode switching tool for
+# USB devices providing multiple states or modes
+#
+# Evaluated by the wrapper script /usr/sbin/usb_modeswitch_dispatcher
+#
+# To enable an option, set it to "1", "yes" or "true" (case doesn't matter)
+# Everything else counts as "disable"
+
+
+# Disable automatic mode switching globally (e.g. to access the original
+# install storage)
+
+DisableSwitching=0
+
+# Disable check for MBIM module presence and configuration globally (to aid
+# special embedded environments)
+
+DisableMBIMGlobal=0
+
+# Enable logging (results in a extensive report file in /var/log, named
+# "usb_modeswitch_<interface-name>" and probably others
+
+EnableLogging=0
+
+
+# Optional increase of "delay_use" for the usb-storage driver; there are hints
+# that a recent kernel default change to 1 sec. may lead to problems, particu-
+# larly with USB 3.0 ports. Set this to at least 3 (seconds) in that case.
+# Does nothing if the current system value is same or higher
+
+#SetStorageDelay=4
+Enter file contents here

--- a/usb_modeswitch.mk
+++ b/usb_modeswitch.mk
@@ -3,6 +3,7 @@
 PRODUCT_PACKAGES += \
 	usb_modeswitch \
 	usb_modeswitch.sh \
+	usb_modeswitch.conf \
 	19d2_2004 \
 	19d2_0115 \
 	19d2_1420 \


### PR DESCRIPTION
Someone testing the new usb_modeswitch on the NU3001; noticed that the usb_modeswitch.conf file was missing.
